### PR TITLE
Added a test

### DIFF
--- a/lib/application_checker.rb
+++ b/lib/application_checker.rb
@@ -378,9 +378,9 @@ module Rails
         value = ""
         # Specifically double quote for finding 'test_help'
         command = if double_quote
-                    "grep -r #{"-P" if perl_regex} --exclude=\*.svn\* \"#{text}\" #{where}"
+                    "grep -r #{"-P" if perl_regex} \"#{text}\" #{where} | grep -v \.svn"
                   else
-                    "grep -r #{"-P" if perl_regex} --exclude=\*.svn\* '#{text}' #{where}"
+                    "grep -r #{"-P" if perl_regex} '#{text}' #{where} | grep -v \.svn"
                   end
         
         Open3.popen3(command) do |stdin, stdout, stderr|

--- a/test/application_checker_test.rb
+++ b/test/application_checker_test.rb
@@ -58,6 +58,12 @@ class ApplicationCheckerTest < ActiveSupport::TestCase
     assert @checker.alerts.has_key?("Soon-to-be-deprecated ActiveRecord calls")
   end
   
+  def test_check_svn_subdirs_are_not_included
+    make_file("app/models/.svn/text-base", "foo.rb.tmp", "Post.find(:all)")
+    @checker.check_ar_methods
+    assert @checker.alerts.empty?
+  end
+  
   def test_check_validation_on_methods
     make_file("app/models", "post.rb", "validate_on_create :comments_valid?")
     @checker.check_validation_on_methods


### PR DESCRIPTION
For the preceding commit, i.e.:
grep with --exclude was resulting in hits on files with names like 'app/models/.svn/text-base/reading_list.rb.svn-base'.  Piping through an additional grep process seems a little wasteful, but it does the job.
