### PR TITLE
Robust tests

### DIFF
--- a/test/application_checker_test.rb
+++ b/test/application_checker_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'application_checker'
 require 'fileutils'
 
-tmp_dir = "#{File.dirname(__FILE__)}/fixtures/tmp"
+tmp_dir = File.expand_path("#{File.dirname(__FILE__)}/fixtures/tmp")
 
 if defined? BASE_ROOT
   BASE_ROOT.replace tmp_dir


### PR DESCRIPTION
Without this patch, I get a failure on a fresh checkout on all rubies, OSX 10.6.4

```
  ................F.................................
  Finished in 0.954686 seconds.

    1) Failure:
  test_check_mailer_api(ApplicationCheckerTest)
      [./test/application_checker_test.rb:183:in `test_check_mailer_api'
       /Users/xavier/.rvm/gems/ruby-1.9.2-p0/gems/activesupport-3.0.0/lib/active_support/testing/setup_and_teardown.rb:67:in `__send__'
       /Users/xavier/.rvm/gems/ruby-1.9.2-p0/gems/activesupport-3.0.0/lib/active_support/testing/setup_and_teardown.rb:67:in `run'
       /Users/xavier/.rvm/gems/ruby-1.9.2-p0/gems/activesupport-3.0.0/lib/active_support/callbacks.rb:413:in `_run_setup_callbacks'
       /Users/xavier/.rvm/gems/ruby-1.9.2-p0/gems/activesupport-3.0.0/lib/active_support/testing/setup_and_teardown.rb:65:in `run']:
  <false> is not true.
```

Cause seems to be the fixture file not getting written to the correct directory. Still unsure why only this test is broken.
