### PR TITLE
Preserve :only & :except options in rails_upgrade routing upgrader

### DIFF
--- a/lib/routes_upgrader.rb
+++ b/lib/routes_upgrader.rb
@@ -275,14 +275,17 @@ module Rails
       end
       
       def to_route_code
+        # preserve :only & :except options
+        copied_options = @options.reject { |k,v| ![:only, :except].member?(k) }
+        copied_options_str = copied_options.empty? ? '' : ', ' + copied_options.inspect.gsub(/\A\{|\}\z/, '')
         
         if !@children.empty? || @options.has_key?(:collection) || @options.has_key?(:member)
-          prefix = ["#{route_method} :#{@name} do"]
+          prefix = ["#{route_method} :#{@name}#{copied_options_str} do"]
           lines = prefix + custom_methods + [@children.map {|r| r.to_route_code}.join("\n"), "end"]
         
           indent_lines(lines)
         else
-          base = "#{route_method} :%s"
+          base = "#{route_method} :%s#{copied_options_str}"
           indent_lines [base % [@name]]
         end
       end

--- a/test/routes_upgrader_test.rb
+++ b/test/routes_upgrader_test.rb
@@ -139,4 +139,14 @@ end
 
     assert_equal new_routes_code, result
   end
+
+  def test_preserves_resources_except_option
+    route = Rails::Upgrading::FakeResourceRoute.new("hats", :except => [:index])
+    assert_equal "resources :hats, :except=>[:index]", route.to_route_code
+  end
+
+  def test_preserves_resources_only_option
+    route = Rails::Upgrading::FakeResourceRoute.new("hats", :only => :show)
+    assert_equal "resources :hats, :only=>:show", route.to_route_code
+  end
 end


### PR DESCRIPTION
This preserves ":only" & ":except" options when converting from Rails 2 `map.resources` syntax to Rails 3 `resources` syntax.  We've actually noticed several issues w/ the route converter on our app, is this an area Rails is interested in beefing up on the rails_upgrade plugin?
