### PR TITLE
fixes routes upgrader to properly emit :via for routes with verbs

### DIFF
--- a/lib/routes_upgrader.rb
+++ b/lib/routes_upgrader.rb
@@ -251,11 +251,15 @@ module Rails
           if @options[:conditions]
             @options[:via] = @options.delete(:conditions).delete(:method)
           end
-        
+
+          if @options[:method]
+            @options[:via] = @options.delete(:method).to_s
+          end
+
           @options ||= {}
           base = (base % [@path, @options.delete(:controller), (@options.delete(:action) || "index")])
           opts = opts_to_string(@options)
-          
+
           route_pieces = ([base] + extra_options + [opts])
           route_pieces.delete("")
           

--- a/test/routes_upgrader_test.rb
+++ b/test/routes_upgrader_test.rb
@@ -139,4 +139,24 @@ end
 
     assert_equal new_routes_code, result
   end
+
+  def test_generates_code_for_delete_route
+    routes_code = "
+    ActionController::Routing::Routes.draw do |map|
+      map.sign_out '/sign_out', :controller => 'sessions', :action => 'destroy', :method => :delete
+    end
+    "
+    new_routes_code = "MyApplication::Application.routes.draw do
+  match '/sign_out' => 'sessions#destroy', :as => :sign_out, :via => 'delete'
+end
+"
+
+    upgrader = Rails::Upgrading::RoutesUpgrader.new
+    upgrader.routes_code = routes_code
+
+    result = upgrader.generate_new_routes
+
+    assert_equal new_routes_code, result
+  end
+
 end


### PR DESCRIPTION
When routes_upgrader encounters a route that is limited to a verb, it doesn't correctly translate the :method into :via. For example, currently:

```
ActionController::Routing::Routes.draw do |map|
  map.sign_out '/sign_out', :controller => 'sessions', :action => 'destroy', :method => :delete
end
```

will translate into 

```
match '/sign_out' => 'sessions#destroy', :as => :sign_out, :method => delete
```

The syntax error in the newly emitted routes file prevents the app from running.
