### PR TITLE
Support for options in namespaces

### DIFF
--- a/lib/routes_upgrader.rb
+++ b/lib/routes_upgrader.rb
@@ -139,9 +139,9 @@ module Rails
         end
       end
       
-      def namespace(name)
+      def namespace(name, options = {})
         debug "mapping namespace #{name}"
-        namespace = FakeNamespace.new(name)
+        namespace = FakeNamespace.new(name, options)
         
         namespace = stack(namespace) do
           yield(self)
@@ -200,16 +200,22 @@ module Rails
     end
     
     class FakeNamespace < RouteObject
-      attr_accessor :routes, :name
+      attr_accessor :routes, :name, :options
       
-      def initialize(name)
+      def initialize(name, options = {})
         @routes = []
-        @name = name
+        @name, @options = name, options
         @indent = RouteRedrawer.indent
       end
       
       def to_route_code
-        lines = ["namespace :#{@name} do", @routes.map {|r| r.to_route_code}, "end"]
+        if !@options.empty?
+          options = ', ' + opts_to_string(@options)
+        else
+          options = ''
+        end
+
+        lines = ["namespace :#{@name}#{options} do", @routes.map {|r| r.to_route_code}, "end"]
         
         indent_lines(lines)
       end

--- a/test/routes_upgrader_test.rb
+++ b/test/routes_upgrader_test.rb
@@ -74,6 +74,14 @@ end
     assert_equal "namespace :static do\nmatch '/about' => 'static#about'\nend\n", ns.to_route_code
   end
   
+  def test_generates_code_for_namespace_with_options
+    ns = Rails::Upgrading::FakeNamespace.new("static", { :path_prefix => 'prefix' })
+    # Add a route to the namespace
+    ns << Rails::Upgrading::FakeRoute.new("/about", {:controller => 'static', :action => 'about'})
+    
+    assert_equal "namespace :static, :path_prefix => 'prefix' do\nmatch '/about' => 'static#about'\nend\n", ns.to_route_code
+  end
+  
   def test_generates_code_for_resources
     route = Rails::Upgrading::FakeResourceRoute.new("hats")
     assert_equal "resources :hats", route.to_route_code


### PR DESCRIPTION
I added support for creating route namespaces that have additional options, as I have an app that used namespace options and the plugin was failing on those.
