### PR TITLE
respect options with resource/resources when having block

### DIFF
--- a/lib/routes_upgrader.rb
+++ b/lib/routes_upgrader.rb
@@ -93,52 +93,34 @@ module Rails
         end
       end
       
-      def resources(*args)
-        if block_given?
-          parent = FakeResourceRoute.new(args.shift)
-          debug "mapping resources #{parent.name} with block"
-          
-          parent = stack(parent) do
-            yield(self)
-          end
-          
-          current_parent << parent
-        else
-          if args.last.is_a?(Hash)
-            current_parent << FakeResourceRoute.new(args.shift, args.pop)
-            debug "mapping resources #{current_parent.last.name} w/o block with args"
-          else
-            args.each do |a|              
-              current_parent << FakeResourceRoute.new(a)
-              debug "mapping resources #{current_parent.last.name}"
+      def resources(*args, &block)
+        _res(FakeResourceRoute, args, &block)
+      end
+
+      def resource(*args, &block)
+        _res(FakeSingletonResourceRoute, args, &block)
+      end
+
+      def _res(klass, args)
+        if args.last.is_a?(Hash)
+          options = args.pop
+          debug "options  #{options.inspect}"
+        end
+
+        args.each do |a|
+          current_parent << klass.new(a, options || {})
+          debug "mapping resources #{current_parent.last.name}"
+
+          if block_given?
+            parent = current_parent.last
+
+            parent = stack(parent) do
+              yield(self)
             end
           end
         end
       end
-      
-      def resource(*args)
-        if block_given?
-          parent = FakeSingletonResourceRoute.new(args.shift)
-          debug "mapping resource #{parent.name} with block"
-          
-          parent = stack(parent) do
-            yield(self)
-          end
-          
-          current_parent << parent
-        else
-          if args.last.is_a?(Hash)
-            current_parent << FakeSingletonResourceRoute.new(args.shift, args.pop)
-            debug "mapping resources #{current_parent.last.name} w/o block with args"
-          else
-            args.each do |a|
-              current_parent << FakeSingletonResourceRoute.new(a)
-              debug "mapping resources #{current_parent.last.name}"
-            end
-          end
-        end
-      end
-      
+
       def namespace(name, options = {})
         debug "mapping namespace #{name}"
         namespace = FakeNamespace.new(name, options)

--- a/test/routes_upgrader_test.rb
+++ b/test/routes_upgrader_test.rb
@@ -92,6 +92,22 @@ end
     assert_equal "resource :hat", route.to_route_code
   end
   
+  def test_generates_code_for_resources_with_block_and_options
+    routes_code = <<-ROUTES
+      ActionController::Routing::Routes.draw do |map|
+        map.resources :people, :collection => {:search => :get} do |p|
+          p.resource :vuvuzela
+        end
+      end
+    ROUTES
+
+    upgrader = Rails::Upgrading::RoutesUpgrader.new
+    upgrader.routes_code = routes_code
+    result = upgrader.generate_new_routes
+
+    assert_equal "MyApplication::Application.routes.draw do\n  resources :people do\n    collection do\n  get :search\n  end\n  \n      resource :vuvuzela\n  end\n\nend\n", result
+  end
+
   def test_generates_code_for_resources_with_special_methods
     route = Rails::Upgrading::FakeResourceRoute.new("hats", {:member => {:wear => :get}, :collection => {:toss => :post}})
     assert_equal "resources :hats do\ncollection do\npost :toss\nend\nmember do\nget :wear\nend\n\nend\n", route.to_route_code


### PR DESCRIPTION
- currently options are ignored when converting resource routes having block (see test)
- refactor out common code 
