### PR TITLE
'send_on' should be 'sent_on'

### DIFF
--- a/lib/application_checker.rb
+++ b/lib/application_checker.rb
@@ -343,16 +343,16 @@ module Rails
         end
       end
 
-      #Check for old ActionMailer :send_on attributes
-      def check_old_action_mailer_send_on_setting
+      #Check for old ActionMailer :sent_on attributes
+      def check_old_action_mailer_sent_on_setting
         files = []
-        lines = grep_for("@sent_on", "app/*")
+        lines = grep_for("sent_on", "app/*")
         files += extract_filenames(lines) || []
 
         unless files.empty?
           alert(
-            "Deprecated ActionMailer attribute :send_on",
-            "This is deprecated without replace.",
+            "Deprecated ActionMailer attribute :sent_on",
+            "Using the new mailer API, you can specify :date to the mail method.",
             "http://stackoverflow.com/questions/7367185/weird-error-when-delivering-mail-undefined-method-index-for-2011-09-09-2215",
             files
           )

--- a/test/application_checker_test.rb
+++ b/test/application_checker_test.rb
@@ -311,6 +311,13 @@ class ApplicationCheckerTest < ActiveSupport::TestCase
     assert ! @checker.alerts.has_key?("Deprecated AJAX helper calls")
   end
 
+  def test_check_old_action_mailer_sent_on_setting
+    make_file("app/models", "mailer.rb", "sent_on Time.now")
+    @checker.check_old_action_mailer_sent_on_setting
+
+    assert @checker.alerts.has_key?("Deprecated ActionMailer attribute :sent_on")
+  end
+
   def teardown
     clear_files
 


### PR DESCRIPTION
In the recent commit, the function name does not match the attribute it is searching for. I adjusted this and added a missing test. I also discovered that :date works in lieu of :sent_on in Rails 3, so I added that info.
