### PR TITLE
Running the upgrade check on engines

### DIFF
--- a/lib/application_checker.rb
+++ b/lib/application_checker.rb
@@ -9,8 +9,8 @@ module Rails
           @relative_base_path = '/'
         else
           @relative_base_path = relative_base_path
-          @relative_base_path += '/' if @relative_base_path.last != '/'
-          @relative_base_path = '/' + @relative_base_path if @relative_base_path.first != '/'
+          @relative_base_path += '/' if @relative_base_path.end_with? '/'
+          @relative_base_path = '/' + @relative_base_path if @relative_base_path.start_with? '/'
         end
 
         raise NotInRailsAppError unless in_rails_app?

--- a/lib/application_checker.rb
+++ b/lib/application_checker.rb
@@ -3,8 +3,15 @@ require 'open3'
 module Rails
   module Upgrading
     class ApplicationChecker
-      def initialize
+      def initialize(relative_base_path = nil)
         @issues = []
+        if relative_base_path.blank?
+          @relative_base_path = '/'
+        else
+          @relative_base_path = relative_base_path
+          @relative_base_path += '/' if @relative_base_path.last != '/'
+          @relative_base_path = '/' + @relative_base_path if @relative_base_path.first != '/'
+        end
 
         raise NotInRailsAppError unless in_rails_app?
       end
@@ -260,7 +267,6 @@ module Rails
 
       # Checks for old-style ERb helpers
       def check_old_helpers
-
         lines = grep_for("<% .*content_tag.* do.*%>", "app/views/**/*")
         lines += grep_for("<% .*javascript_tag.* do.*%>", "app/views/**/*")
         lines += grep_for("<% .*form_for.* do.*%>", "app/views/**/*")
@@ -400,7 +406,7 @@ module Rails
 
       # Sets a base path for finding files; mostly for testing
       def base_path
-        Dir.pwd + "/"
+        Dir.pwd + @relative_base_path # "/"
       end
 
       # Use the grep utility to find a string in a set of files

--- a/lib/tasks/rails_upgrade_tasks.rake
+++ b/lib/tasks/rails_upgrade_tasks.rake
@@ -11,7 +11,7 @@ namespace :rails do
   namespace :upgrade do
     desc "Runs a battery of checks on your Rails 2.x app and generates a report on required upgrades for Rails 3"
     task :check do
-      checker = Rails::Upgrading::ApplicationChecker.new
+      checker = Rails::Upgrading::ApplicationChecker.new(ENV['BASE_PATH'])
       checker.run
     end
 


### PR DESCRIPTION
Hi,

I love this plugin, but found a drawback. It only runs the battery of tests in the main app, and not for controllers, views, models, etc. found in engines. So I added a BASE_PATH parameter to the rails:upgrade:check task so that a path to the plugin's folder can be specified.

So this now works: rake rails:upgrade:check BASE_PATH=vendor/plugins/XXXX

Of course such parameter is optional so it doesn't break the original syntax. It was a very simple change, but I thought it was extremely useful in my own projects, so I thought I share.

Thank you for taking the time to read this.

Take care,
   Andres Montano
   Tibetan and Himalayan Library, University of Virginia 
