### PR TITLE
Added Support for App Names with Dots in Them

### DIFF
--- a/lib/new_configuration_generator.rb
+++ b/lib/new_configuration_generator.rb
@@ -36,7 +36,7 @@ require 'rails/all'
 
 Bundler.require(:default, Rails.env) if defined?(Bundler)
 
-module #{app_name.classify}
+module #{app_name.gsub(/\W/, '_').squeeze('_').camelize}
   class Application < Rails::Application
     config.autoload_paths += [config.root.join('lib')]
     config.encoding = 'utf-8'

--- a/lib/routes_upgrader.rb
+++ b/lib/routes_upgrader.rb
@@ -332,7 +332,7 @@ module Rails
           r.to_route_code
         end.join("\n")
         
-        "#{app_name.underscore.classify}::Application.routes.draw do\n#{@new_code}\nend\n"
+        "#{app_name.gsub(/\W/, '_').squeeze('_').camelize}::Application.routes.draw do\n#{@new_code}\nend\n"
       end
       
     private


### PR DESCRIPTION
I encountered a bug when using this gem to upgrade some legacy rails 2 applications.  When the name of the root directory for these apps included dots, the application name generated by the routes upgrader and configuration generator were inconsistent with the way rails 3 handles such root directory names.  Specifically, the part of the directory name following the last dot was used.  Here is an example using rails 2:

<pre>
$ rails app.name.with.dots.in.it
      create  
...
</pre><pre>
$ cd app.name.with.dots.in.it/
</pre><pre>
$ script/plugin install git://github.com/rails/rails_upgrade.git
Initialized empty Git repository in 
...
</pre><pre>
$ rake rails:upgrade:routes
It::Application.routes.draw do
  match '/:controller(/:action(/:id))'
end
</pre><pre>
$ rake rails:upgrade:configuration
# Put this in config/application.rb
require File.expand_path('../boot', __FILE__)

require 'rails/all'

Bundler.require(:default, Rails.env) if defined?(Bundler)

module It
  class Application < Rails::Application
    config.autoload_paths += [config.root.join('lib')]
    config.encoding = 'utf-8'
    # Settings in config/environments/* take precedence over those specified here.
    # Application configuration should go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded.
  
    # Add additional load paths for your own custom dirs
    # config.autoload_paths += %W( #{RAILS_ROOT}/extras )
  
    # Specify gems that this application depends on and have them installed with rake gems:install
    # config.gem "bj"
    # config.gem "hpricot", :version => '0.6', :source => "http://code.whytheluckystiff.net"
    # config.gem "sqlite3-ruby", :lib => "sqlite3"
    # config.gem "aws-s3", :lib => "aws/s3"
  
    # Only load the plugins named here, in the order given (default is alphabetical).
    # :all can be used as a placeholder for all plugins not explicitly named
    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
  
    # Skip frameworks you're not going to use. To use Rails without a database,
    # you must remove the Active Record framework.
    # config.frameworks -= [ :active_record, :active_resource, :action_mailer ]
  
    # Activate observers that should always be running
    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
  
    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
    # Run "rake -D time" for a list of tasks for finding time zone names.
    config.time_zone = 'UTC'
  
    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
    # config.i18n.default_locale = :de
  end
end
</pre>


Notice that the new routes file contains the line

<pre>It::Application.routes.draw do</pre>

and the code for config/application.rb includes the line

<pre>module It</pre>

Had the application been generated in rails 3 using `rails new app.name.with.dots.in.it`, those lines would read

<pre>AppNameWithDotsInIt::Application.routes.draw do</pre>

and

<pre>module AppNameWithDotsInIt</pre>

respectively.

Rails 3 seems to use the method `Rails::Generators::AppGenerator.app_const_base` to 'classify' the app name.  Here is the code, retrieved from http://api.rubyonrails.org/classes/Rails/Generators/AppGenerator.html#method-i-app_const_base

``` ruby
# File railties/lib/rails/generators/rails/app/app_generator.rb, line 261
def app_const_base
  @app_const_base ||= defined_app_const_base || app_name.gsub(/\W/, '_').squeeze('_').camelize
end
```

by replacing the `.classify` and `.underscore.classify` in the places where rails_upgrade generates this app_const_base string with `.gsub(/\W/, '_').squeeze('_').camelize`, we can better emulate a new rails 3 app.  Here are the results using my fork:

<pre>
$ cd ..
</pre><pre>
$ rm -r app.name.with.dots.in.it
</pre><pre>
$ rails app.name.with.dots.in.it
      create  
...
</pre><pre>
$ cd app.name.with.dots.in.it/
</pre><pre>
$ script/plugin install https://github.com/HandyAndyShortStack/rails_upgrade.git
Initialized empty Git repository in 
...
</pre><pre>
$ rake rails:upgrade:routes
AppNameWithDotsInIt::Application.routes.draw do
  match '/:controller(/:action(/:id))'
end
</pre><pre>
$ rake rails:upgrade:configuration
# Put this in config/application.rb
require File.expand_path('../boot', __FILE__)

require 'rails/all'

Bundler.require(:default, Rails.env) if defined?(Bundler)

module AppNameWithDotsInIt
  class Application < Rails::Application
    config.autoload_paths += [config.root.join('lib')]
    config.encoding = 'utf-8'
    # Settings in config/environments/* take precedence over those specified here.
    # Application configuration should go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded.
  
    # Add additional load paths for your own custom dirs
    # config.autoload_paths += %W( #{RAILS_ROOT}/extras )
  
    # Specify gems that this application depends on and have them installed with rake gems:install
    # config.gem "bj"
    # config.gem "hpricot", :version => '0.6', :source => "http://code.whytheluckystiff.net"
    # config.gem "sqlite3-ruby", :lib => "sqlite3"
    # config.gem "aws-s3", :lib => "aws/s3"
  
    # Only load the plugins named here, in the order given (default is alphabetical).
    # :all can be used as a placeholder for all plugins not explicitly named
    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
  
    # Skip frameworks you're not going to use. To use Rails without a database,
    # you must remove the Active Record framework.
    # config.frameworks -= [ :active_record, :active_resource, :action_mailer ]
  
    # Activate observers that should always be running
    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
  
    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
    # Run "rake -D time" for a list of tasks for finding time zone names.
    config.time_zone = 'UTC'
  
    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
    # config.i18n.default_locale = :de
  end
end
</pre>

Thank you so much for making this plugin!  It has helped me out immensely.  I hope this pull request will help prevent headaches for future developers if you accept it.
-Andy
