### PR TITLE
Use rdoc to fix error of rake/rdoctask is deprecated.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test
@@ -13,7 +13,7 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Generate documentation for the rails_upgrade plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = 'Rails-upgrade'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Generate documentation for the rails_upgrade plugin.'
-RDoc::Task.new.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = 'Rails-upgrade'
   rdoc.options << '--line-numbers' << '--inline-source'


### PR DESCRIPTION
rake/rdoctask is deprecated. Use rdoc/task instead (in RDoc 2.4.2+)
